### PR TITLE
Re-convert cooljeanius/mdnsd to GitHub Actions

### DIFF
--- a/.github/workflows/mdnsd.yml
+++ b/.github/workflows/mdnsd.yml
@@ -4,12 +4,15 @@ on:
     branches:
     - "**/*"
   pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.0.0
 #     # 'Transformers::TravisCI::Scripts::Dependencies' dependencies are currently unsupported
 #     # 'compiler' was not transformed because there is no suitable equivalent in GitHub Actions
     - run: "./configure && make && make check"
@@ -18,3 +21,6 @@ jobs:
         compiler:
         - clang
         - gcc
+        os:
+        - ubuntu-latest
+        - macos-latest

--- a/.github/workflows/mdnsd.yml
+++ b/.github/workflows/mdnsd.yml
@@ -4,9 +4,6 @@ on:
     branches:
     - "**/*"
   pull_request:
-concurrency:
-#   # This item has no matching transformer
-#   maximum_number_of_builds: 0
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/cooljeanius/mdnsd) :tada: (again)