### PR TITLE
Fix code scanning alert no. 1: Potential use after free

### DIFF
--- a/mdnsd.c
+++ b/mdnsd.c
@@ -787,7 +787,11 @@ void mdnsd_set_raw(mdnsd d, mdnsdr r, char *data, int len)
     free(r->rr.rdata);
     r->rr.rdata = NULL;
     r->rr.rdata = (unsigned char *)malloc(len);
-    memcpy(r->rr.rdata,data,len);
+    if (r->rr.rdata == NULL) {
+        fprintf(stderr, "Memory allocation failed in mdnsd_set_raw\n");
+        return;
+    }
+    memcpy(r->rr.rdata, data, len);
     r->rr.rdlen = len;
     _r_publish(d,r);
 }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/mdnsd/security/code-scanning/1](https://github.com/cooljeanius/mdnsd/security/code-scanning/1)

To fix the use-after-free issue, we need to ensure that the pointer `r->rr.rdata` is not accessed after it has been freed unless it is reassigned a valid memory block. Additionally, we should add error handling to check if `malloc` fails and handle that scenario appropriately.

- First, free the existing memory block pointed to by `r->rr.rdata`.
- Set the pointer to `NULL` immediately after freeing it to avoid accidental use.
- Allocate a new memory block and check if the allocation was successful.
- If the allocation fails, handle the error appropriately (e.g., by logging an error message and returning from the function).
- If the allocation succeeds, proceed with copying the data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
